### PR TITLE
Simply shows settings window instead of running it modal

### DIFF
--- a/BrightIntosh/AppDelegate.swift
+++ b/BrightIntosh/AppDelegate.swift
@@ -159,7 +159,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     
     @objc func openSettings() {
         NSApplication.shared.activate(ignoringOtherApps: true)
-        NSApp.runModal(for: settingsWindowController.window!)
+        settingsWindowController.showWindow(self)
     }
     
     func welcomeWindow() {


### PR DESCRIPTION
Showing the settings window via the window controller and not by running it modal fixes the weird sound behaviour mentioned in #84.